### PR TITLE
Issue separate normalize

### DIFF
--- a/hydrant/tasks/panoply_cmap_analysis/panoply_cmap_analysis.wdl
+++ b/hydrant/tasks/panoply_cmap_analysis/panoply_cmap_analysis.wdl
@@ -65,7 +65,7 @@ task panoply_cmap_connectivity {
 
   runtime {
     docker : "broadcptacdev/panoply_cmap_analysis:latest"
-    memory : select_first ([memory, 32]) + "GB"
+    memory : select_first ([memory, 60]) + "GB"
     disks : "local-disk " + select_first ([disk_space, 64]) + " SSD"
     cpu : select_first ([num_threads, permutations+1]) + ""
     preemptible : select_first ([num_preemptions, 1])

--- a/hydrant/tasks/panoply_cna_correlation/panoply_cna_correlation.wdl
+++ b/hydrant/tasks/panoply_cna_correlation/panoply_cna_correlation.wdl
@@ -31,7 +31,7 @@ task panoply_cna_correlation {
 
   runtime {
     docker : "broadcptacdev/panoply_cna_setup:latest"
-    memory : select_first ([memory, 12]) + "GB"
+    memory : select_first ([memory, 16]) + "GB"
     disks : "local-disk " + select_first ([disk_space, 20]) + " SSD"
     cpu : select_first ([num_threads, 1]) + ""
     preemptible : select_first ([num_preemptions, 0])

--- a/hydrant/tasks/panoply_unified_assemble_results/panoply_unified_assemble_results.wdl
+++ b/hydrant/tasks/panoply_unified_assemble_results/panoply_unified_assemble_results.wdl
@@ -164,7 +164,7 @@ task panoply_unified_assemble_results {
   runtime {
     docker : "broadcptacdev/panoply_common:latest"
     memory : select_first ([memory, 16]) + "GB"
-    disks : "local-disk " + select_first ([disk_space, 20]) + " SSD"
+    disks : "local-disk " + select_first ([disk_space, 32]) + " SSD"
     cpu : select_first ([num_threads, 1]) + ""
     preemptible : select_first ([num_preemptions, 0])
   }

--- a/hydrant/workflows/panoply_main/panoply_main.wdl
+++ b/hydrant/workflows/panoply_main/panoply_main.wdl
@@ -39,7 +39,7 @@ workflow panoply_main {
   File? cluster_enrichment_groups
 
   ## cmap inputs
-  Int cmap_n_permutations = 5
+  Int cmap_n_permutations = 10
   File? cmap_enrichment_groups
   File subset_list_file = "gs://fc-de501ca1-0ae7-4270-ae76-6c99ea9a6d5b/cmap-data/cmap-data-subsets-index.txt"
   File cmap_level5_data = "gs://fc-de501ca1-0ae7-4270-ae76-6c99ea9a6d5b/cmap-data/annotated_GSE92742_Broad_LINCS_Level5_COMPZ_geneKDsubset_n36720x12328.gctx"

--- a/hydrant/workflows/panoply_normalize_ms_data_workflow/panoply_normalize_ms_data_workflow.wdl
+++ b/hydrant/workflows/panoply_normalize_ms_data_workflow/panoply_normalize_ms_data_workflow.wdl
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2020 The Broad Institute, Inc. All rights reserved.
+#
+import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_normalize_ms_data/versions/17/plain-WDL/descriptor" as normalize_wdl
+import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_normalize_ms_data_report/versions/5/plain-WDL/descriptor" as normalize_report_wdl
+
+workflow panoply_normalize_ms_data_workflow {
+	File input_pome
+	String ome_type
+	String job_identifier
+	File yaml
+	String? normalizeProteomics # "true" or "false"
+
+	Int? ndigits
+  	Float? na_max
+  	String? gene_id_col
+  	Float? sd_filter_threshold
+  	Float? min_numratio_fraction
+  	
+
+	call normalize_wdl.panoply_normalize_ms_data {
+    	input:
+      		inputData = input_pome,
+      		type = ome_type,
+      		standalone = "true",
+      		analysisDir = job_identifier,
+      		yaml = yaml,
+      		ndigits = ndigits,
+      		naMax = na_max,
+      		geneIdCol=gene_id_col,
+      		sdFilterThreshold=sd_filter_threshold,
+      		minNumratioFraction=min_numratio_fraction,
+      		normalizeProteomics=normalizeProteomics
+  	}
+
+  	call normalize_report_wdl.panoply_normalize_ms_data_report {
+    	input:
+      		tarball = panoply_normalize_ms_data.output_tar,
+      		label = job_identifier,
+      		type = ome_type,
+      		tmpDir = "tmp",
+      		yaml = panoply_normalize_ms_data.output_yaml
+  	}
+
+  	output {
+  		File normalized_data_table = panoply_normalize_ms_data.outputs
+  		File normalized_tar = panoply_normalize_ms_data.output_tar
+  		File normalize_report = panoply_normalize_ms_data_report.report
+
+  	}
+  }

--- a/hydrant/workflows/panoply_unified_workflow/panoply_unified_workflow.wdl
+++ b/hydrant/workflows/panoply_unified_workflow/panoply_unified_workflow.wdl
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2020 The Broad Institute, Inc. All rights reserved.
 #
+import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_normalize_ms_data_workflow/versions/1/plain-WDL/descriptor" as normalize_wdl
 import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_main/versions/3/plain-WDL/descriptor" as main_wdl
 import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_blacksheep_workflow/versions/1/plain-WDL/descriptor" as blacksheep_wdl
 import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_mo_nmf_gct/versions/16/plain-WDL/descriptor" as mo_nmf_wdl
@@ -21,10 +22,15 @@ workflow panoply_unified_workflow {
   String job_id
   String run_ptmsea
   String run_cmap
+
+  # Normalize specific optional params:
+  String? normalizeProteomics # "true" or "false"
+
   
   Array[File] omes = ["${prote_ome}", "${phospho_ome}", "${acetyl_ome}", "${ubiquityl_ome}"]
   Array[File] data = ["${rna_data}", "${cna_data}"]
   
+  # Turn the type data (RNA+CNA) into an array of pairs:
   call make_pairs_wdl.panoply_make_pairs_workflow as type_pairs {
     input:
       files = data,
@@ -32,6 +38,7 @@ workflow panoply_unified_workflow {
 
   }
 
+  # Make the array of ome pairs to input into normalize:
   call make_pairs_wdl.panoply_make_pairs_workflow as ome_pairs {
     input:
       files = omes,
@@ -39,8 +46,31 @@ workflow panoply_unified_workflow {
 
   }
 
-  ### MAIN:
+  ### NORMALIZE:
+  ### Normalize the data first so downstream modules (NMF etc) can run in parallel to main:
   scatter (pair in ome_pairs.zipped) {
+    if ("${pair.right}" != "") {
+      call normalize_wdl.panoply_normalize_ms_data_workflow as norm {
+        input:
+          input_pome="${pair.right}",
+          ome_type="${pair.left}",
+          job_identifier="${job_id}-${pair.left}",
+          yaml="${yaml}",
+          normalizeProteomics=normalizeProteomics
+      }
+    }
+  }
+
+  # Make an array of pairs from the normalized data for input to main and other modules:
+  call make_pairs_wdl.panoply_make_pairs_workflow as norm_pairs {
+    input:
+      files = norm.normalized_data_table,
+      suffix = "-normalized_table-output.gct"
+
+  }
+
+  ### MAIN:
+  scatter (pair in norm_pairs.zipped) {
     if ("${pair.right}" != "") {
         call main_wdl.panoply_main as pome {
           input:
@@ -60,26 +90,19 @@ workflow panoply_unified_workflow {
     }
   }
   
-  call make_pairs_wdl.panoply_make_pairs_workflow as norm_pairs {
-    input:
-      files = pome.normalized_data_table,
-      suffix = "-normalized_table-output.gct"
 
-  }
-
+  # This takes the array of pairs of normalized proteomics data and combines it with the array of pairs of RNA+CNA data for Blacksheep use:
   Array[Pair[String?,File?]] all_pairs = flatten([norm_pairs.zipped,type_pairs.zipped])
   
   ### BLACKSHEEP:
   scatter (pair in all_pairs) {
     if ("${pair.right}" != "") {
-      if ("${pair.left}" != "cna") {
-        call blacksheep_wdl.panoply_blacksheep_workflow as outlier {
-          input:
-            input_gct = "${pair.right}",
-            master_yaml = "${yaml}",
-            output_prefix = "${pair.left}",
-            type = "${pair.left}"
-        }
+      call blacksheep_wdl.panoply_blacksheep_workflow as outlier {
+        input:
+          input_gct = "${pair.right}",
+          master_yaml = "${yaml}",
+          output_prefix = "${pair.left}",
+          type = "${pair.left}"
       }
     }
   }
@@ -89,7 +112,7 @@ workflow panoply_unified_workflow {
     input:
       yaml_file = yaml,
       label = job_id,
-      omes = pome.normalized_data_table,
+      omes = norm.normalized_data_table,
       rna_ome = rna_data,
       cna_ome = cna_data
   }
@@ -114,7 +137,7 @@ workflow panoply_unified_workflow {
       main_summary = pome.summary_and_ssgsea,
       cmap_output = pome.cmap_output,
       cmap_ssgsea_output = pome.cmap_ssgsea_output,
-      norm_report = pome.norm_report,
+      norm_report = norm.normalize_report,
       rna_corr_report = pome.rna_corr_report,
       cna_corr_report = pome.cna_corr_report,
       sampleqc_report = pome.sample_qc_report,

--- a/src/panoply_common/master-parameters.yaml
+++ b/src/panoply_common/master-parameters.yaml
@@ -87,7 +87,7 @@ panoply_cmap_analysis:
   cna_threshold: 0.3               # copy number up/down if abs (log2(copy number) - 1) is > cna.threshold (default: 0.3)
   cna_effects_threshold: 15        # min number of samples with up/down copy number to include gene for CMAP analysis (default: 15)
   min_sigevents: 20                # gene must have at least this many significant trans events to be considered (default: 20)  
-  max_sigevents: 1800              # if a gene has more then max.sigevents, the top max.sigevents will be chosen
+  max_sigevents: 1500              # if a gene has more then max.sigevents, the top max.sigevents will be chosen
   top_N: 500                       # maximum number of genes to run CMAP enrichment on (default: 500)
   fdr_pvalue: 0.05                 # FDR for CNA correlations (default: 0.05)
   log_transform: FALSE      # if TRUE, log transform input data


### PR DESCRIPTION
Updated panoply_normalize_ms_data and panoply_normalize_ms_data_report to be a workflow separate from panoply_main. Normalize workflow was added to panoply_unified_workflow and outputs were channeled to appropriate modules requiring normalized ome input gct files.  

Various default parameters were updated for modules, particularly those needing runtime parameter changes such as memory.

In panoply_unified_workflow, the Blacksheep workflow will now run on cna data when provided as pipeline input.