### PR TITLE
fix the script name in panoply_ssgsea_report

### DIFF
--- a/hydrant/tasks/panoply_ssgsea_report/panoply_ssgsea_report.wdl
+++ b/hydrant/tasks/panoply_ssgsea_report/panoply_ssgsea_report.wdl
@@ -14,7 +14,7 @@ task panoply_ssgsea_report {
 
   command {
     set -euo pipefail
-    Rscript /home/pgdac/src/rmd-ssgsea.r -t ${tarball} -l ${label} -y ${cfg_yaml} -z /home/pgdac/src/
+    Rscript /home/pgdac/src/rmd-ssgsea.R -t ${tarball} -l ${label} -y ${cfg_yaml} -z /home/pgdac/src/
   }
 
   output {


### PR DESCRIPTION
I am trying to run the `panoply_ssgsea_report` locally. It seems to me that there is no `rmd-ssgsea.r` in the docker image. Instead, there is a `rmd-ssgsea.R` script.