### PR TITLE
Replace Firecloud WDL imports with GitHub raw URLs

### DIFF
--- a/hydrant/workflows/panoply_association_workflow/panoply_association_workflow.wdl
+++ b/hydrant/workflows/panoply_association_workflow/panoply_association_workflow.wdl
@@ -1,11 +1,11 @@
 #
 # Copyright (c) 2020 The Broad Institute, Inc. All rights reserved.
 #
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_association/versions/10/plain-WDL/descriptor" as assoc_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_accumulate/versions/8/plain-WDL/descriptor" as accum_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_preprocess_gct/versions/4/plain-WDL/descriptor" as preprocess_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_ssgsea/versions/15/plain-WDL/descriptor" as ssgsea_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_association_report/versions/9/plain-WDL/descriptor" as 	assoc_report_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_association/panoply_association.wdl" as assoc_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_accumulate/panoply_accumulate.wdl" as accum_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_preprocess_gct/panoply_preprocess_gct.wdl" as preprocess_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_ssgsea/panoply_ssgsea.wdl" as ssgsea_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_association_report/panoply_association_report.wdl" as 	assoc_report_wdl
 
 ################################################
 ##  workflow: panoply_association + panoply_accumulate + panoply_ssgsea + panoply_association_report

--- a/hydrant/workflows/panoply_blacksheep_workflow/panoply_blacksheep_workflow.wdl
+++ b/hydrant/workflows/panoply_blacksheep_workflow/panoply_blacksheep_workflow.wdl
@@ -1,8 +1,8 @@
 #
 # Copyright (c) 2020 The Broad Institute, Inc. All rights reserved.
 #
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_blacksheep/versions/11/plain-WDL/descriptor" as blacksheep_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_blacksheep_report/versions/6/plain-WDL/descriptor" as blacksheep_report_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_blacksheep/panoply_blacksheep.wdl" as blacksheep_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_blacksheep_report/panoply_blacksheep_report.wdl" as blacksheep_report_wdl
 
 workflow panoply_blacksheep_workflow {
     File input_gct

--- a/hydrant/workflows/panoply_clumps_ptm_workflow/panoply_clumps_ptm_workflow.wdl
+++ b/hydrant/workflows/panoply_clumps_ptm_workflow/panoply_clumps_ptm_workflow.wdl
@@ -1,11 +1,11 @@
 #
 # Copyright (c) 2025 The Broad Institute, Inc. All rights reserved.
 #
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_clumps_ptm_diffexp/versions/5/plain-WDL/descriptor" as diffexp_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_clumps_ptm_mapping/versions/17/plain-WDL/descriptor" as mapping_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_clumps_ptm/versions/23/plain-WDL/descriptor" as analysis_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_clumps_ptm_postprocess/versions/8/plain-WDL/descriptor" as postprocess_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_clumps_ptm_report/versions/6/plain-WDL/descriptor" as report_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_clumps_ptm_diffexp/panoply_clumps_ptm_diffexp.wdl" as diffexp_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_clumps_ptm_mapping/panoply_clumps_ptm_mapping.wdl" as mapping_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_clumps_ptm/panoply_clumps_ptm.wdl" as analysis_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_clumps_ptm_postprocess/panoply_clumps_ptm_postprocess.wdl" as postprocess_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_clumps_ptm_report/panoply_clumps_ptm_report.wdl" as report_wdl
 
 ################################################
 ##  workflow: panoply_clumps_ptm_diffexp + panoply_clumps_ptm_mapping + panoply_clumps_ptm

--- a/hydrant/workflows/panoply_immune_analysis_workflow/panoply_immune_analysis_workflow.wdl
+++ b/hydrant/workflows/panoply_immune_analysis_workflow/panoply_immune_analysis_workflow.wdl
@@ -1,8 +1,8 @@
 #
 # Copyright (c) 2020 The Broad Institute, Inc. All rights reserved.
 #
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_immune_analysis/versions/21/plain-WDL/descriptor" as immune_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_immune_analysis_report/versions/2/plain-WDL/descriptor" as immune_report_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_immune_analysis/panoply_immune_analysis.wdl" as immune_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_immune_analysis_report/panoply_immune_analysis_report.wdl" as immune_report_wdl
 
 workflow panoply_immune_analysis_workflow {
     File inputData

--- a/hydrant/workflows/panoply_main/panoply_main.wdl
+++ b/hydrant/workflows/panoply_main/panoply_main.wdl
@@ -2,22 +2,22 @@
 # Copyright (c) 2020 The Broad Institute, Inc. All rights reserved.
 #
 
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_main_internal/versions/1/plain-WDL/descriptor" as panoply_main_internal
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_main_internal/panoply_main_internal.wdl" as panoply_main_internal
 ## Proteogenomic
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_harmonize/versions/7/plain-WDL/descriptor" as harmonize_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_rna_protein_correlation/versions/7/plain-WDL/descriptor" as rna_prot_corr_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_rna_protein_correlation_report/versions/6/plain-WDL/descriptor" as rna_corr_report_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_cna_setup/versions/7/plain-WDL/descriptor" as cna_setup_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_cna_correlation/versions/7/plain-WDL/descriptor" as cna_corr_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_cna_correlation_report/versions/6/plain-WDL/descriptor" as cna_corr_report_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_cmap_analysis/versions/6/plain-WDL/descriptor" as cmap_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_harmonize/panoply_harmonize.wdl" as harmonize_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_rna_protein_correlation/panoply_rna_protein_correlation.wdl" as rna_prot_corr_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_rna_protein_correlation_report/panoply_rna_protein_correlation_report.wdl" as rna_corr_report_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_cna_setup/panoply_cna_setup.wdl" as cna_setup_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_cna_correlation/panoply_cna_correlation.wdl" as cna_corr_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_cna_correlation_report/panoply_cna_correlation_report.wdl" as cna_corr_report_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_cmap_analysis/panoply_cmap_analysis.wdl" as cmap_wdl
 ## Sample-QC
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_sampleqc/versions/8/plain-WDL/descriptor" as sampleqc_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_sampleqc_report/versions/5/plain-WDL/descriptor" as sampleqc_report_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_cosmo/versions/11/plain-WDL/descriptor" as cosmo_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_omicsev/versions/21/plain-WDL/descriptor" as omicsev_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_sampleqc/panoply_sampleqc.wdl" as sampleqc_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_sampleqc_report/panoply_sampleqc_report.wdl" as sampleqc_report_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_cosmo/panoply_cosmo.wdl" as cosmo_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_omicsev/panoply_omicsev.wdl" as omicsev_wdl
 ## Support
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_download/versions/23/plain-WDL/descriptor" as download_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_download/panoply_download.wdl" as download_wdl
 
 
 workflow panoply_main {

--- a/hydrant/workflows/panoply_main_internal/panoply_main_internal.wdl
+++ b/hydrant/workflows/panoply_main_internal/panoply_main_internal.wdl
@@ -2,14 +2,14 @@
 # Copyright (c) 2025 The Broad Institute, Inc. All rights reserved.
 #
 
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_association_workflow/versions/14/plain-WDL/descriptor" as assoc_workflow
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_blacksheep_workflow/versions/15/plain-WDL/descriptor" as blacksheep_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_ssgsea_workflow/versions/10/plain-WDL/descriptor" as panoply_ssgsea_workflow_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_nmf_internal_workflow/versions/24/plain-WDL/descriptor" as nmf_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_association_workflow/panoply_association_workflow.wdl" as assoc_workflow
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_blacksheep_workflow/panoply_blacksheep_workflow.wdl" as blacksheep_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_ssgsea_workflow/panoply_ssgsea_workflow.wdl" as panoply_ssgsea_workflow_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_nmf_internal_workflow/panoply_nmf_internal_workflow.wdl" as nmf_wdl
 
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_immune_analysis_workflow/versions/47/plain-WDL/descriptor" as immune_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_immune_analysis_workflow/panoply_immune_analysis_workflow.wdl" as immune_wdl
 
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_check_yaml_default/versions/9/plain-WDL/descriptor" as check_yaml_default_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_check_yaml_default/panoply_check_yaml_default.wdl" as check_yaml_default_wdl
 
 workflow panoply_main_internal {
 

--- a/hydrant/workflows/panoply_metaboanalyst_workflow/panoply_metaboanalyst_workflow.wdl
+++ b/hydrant/workflows/panoply_metaboanalyst_workflow/panoply_metaboanalyst_workflow.wdl
@@ -1,8 +1,8 @@
 #
 # Copyright (c) 2025 The Broad Institute, Inc. All rights reserved.
 #
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_metaboanalyst/versions/2/plain-WDL/descriptor" as metaboanalyst_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_metaboanalyst_report/versions/1/plain-WDL/descriptor" as metaboanalyst_report_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_metaboanalyst/panoply_metaboanalyst.wdl" as metaboanalyst_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_metaboanalyst_report/panoply_metaboanalyst_report.wdl" as metaboanalyst_report_wdl
 
 ################################################
 ##  workflow: panoply_metaboanalyst + panoply_metaboanalyst_report

--- a/hydrant/workflows/panoply_nmf_internal_workflow/panoply_nmf_internal_workflow.wdl
+++ b/hydrant/workflows/panoply_nmf_internal_workflow/panoply_nmf_internal_workflow.wdl
@@ -1,11 +1,11 @@
 #
 # Copyright (c) 2020 The Broad Institute, Inc. All rights reserved.
 #
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_nmf_balance_omes/versions/9/plain-WDL/descriptor" as panoply_nmf_balance_omes_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_nmf/versions/8/plain-WDL/descriptor" as panoply_nmf_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_nmf_postprocess/versions/9/plain-WDL/descriptor" as panoply_nmf_postprocess_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_nmf_report/versions/5/plain-WDL/descriptor" as panoply_nmf_report_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_ssgsea_workflow/versions/7/plain-WDL/descriptor" as panoply_ssgsea_workflow_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_nmf_balance_omes/panoply_nmf_balance_omes.wdl" as panoply_nmf_balance_omes_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_nmf/panoply_nmf.wdl" as panoply_nmf_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_nmf_postprocess/panoply_nmf_postprocess.wdl" as panoply_nmf_postprocess_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_nmf_report/panoply_nmf_report.wdl" as panoply_nmf_report_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_ssgsea_workflow/panoply_ssgsea_workflow.wdl" as panoply_ssgsea_workflow_wdl
 
 ################################################
 ##  workflow: nmf_balance_omes + nmf + nmf_report + ssgsea + ssgsea_report

--- a/hydrant/workflows/panoply_nmf_workflow/panoply_nmf_workflow.wdl
+++ b/hydrant/workflows/panoply_nmf_workflow/panoply_nmf_workflow.wdl
@@ -1,10 +1,10 @@
 #
 # Copyright (c) 2023 The Broad Institute, Inc. All rights reserved.
 #
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_select_all_pairs/versions/3/plain-WDL/descriptor" as select_pairs
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_nmf_internal_workflow/versions/24/plain-WDL/descriptor" as nmf_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_sankey_workflow/versions/12/plain-WDL/descriptor" as sankey_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_nmf_assemble_results/versions/17/plain-WDL/descriptor" as assemble_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_select_all_pairs/panoply_select_all_pairs.wdl" as select_pairs
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_nmf_internal_workflow/panoply_nmf_internal_workflow.wdl" as nmf_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_sankey_workflow/panoply_sankey_workflow.wdl" as sankey_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_nmf_assemble_results/panoply_nmf_assemble_results.wdl" as assemble_wdl
 
 
 ################################################

--- a/hydrant/workflows/panoply_normalize_filter_workflow/panoply_normalize_filter_workflow.wdl
+++ b/hydrant/workflows/panoply_normalize_filter_workflow/panoply_normalize_filter_workflow.wdl
@@ -1,9 +1,9 @@
 #
 # Copyright (c) 2020 The Broad Institute, Inc. All rights reserved.
 #
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_normalize_ms_data/versions/6/plain-WDL/descriptor" as normalize_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_filter/versions/2/plain-WDL/descriptor" as filter_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_normalize_ms_data_report/versions/5/plain-WDL/descriptor" as normalize_report_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_normalize_ms_data/panoply_normalize_ms_data.wdl" as normalize_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_filter/panoply_filter.wdl" as filter_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_normalize_ms_data_report/panoply_normalize_ms_data_report.wdl" as normalize_report_wdl
 
 workflow panoply_normalize_filter_workflow {
 	File input_pome

--- a/hydrant/workflows/panoply_process_SM_table/panoply_process_SM_table.wdl
+++ b/hydrant/workflows/panoply_process_SM_table/panoply_process_SM_table.wdl
@@ -1,9 +1,9 @@
 #
 # Copyright (c) 2020 The Broad Institute, Inc. All rights reserved.
 #
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_parse_sm_table/versions/7/plain-WDL/descriptor" as parse_sm_table
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_normalize_ms_data/versions/11/plain-WDL/descriptor" as normalize
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_normalize_ms_data_report/versions/5/plain-WDL/descriptor" as normalize_report
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_parse_sm_table/panoply_parse_sm_table.wdl" as parse_sm_table
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_normalize_ms_data/panoply_normalize_ms_data.wdl" as normalize
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_normalize_ms_data_report/panoply_normalize_ms_data_report.wdl" as normalize_report
 
 workflow panoply_process_SM_table {
 

--- a/hydrant/workflows/panoply_sankey_workflow/panoply_sankey_workflow.wdl
+++ b/hydrant/workflows/panoply_sankey_workflow/panoply_sankey_workflow.wdl
@@ -1,8 +1,8 @@
 #
 # Copyright (c) 2020 The Broad Institute, Inc. All rights reserved.
 #
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_sankey/versions/9/plain-WDL/descriptor" as sankey_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_sankey_report/versions/3/plain-WDL/descriptor" as sankey_report_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_sankey/panoply_sankey.wdl" as sankey_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_sankey_report/panoply_sankey_report.wdl" as sankey_report_wdl
 
 
 workflow panoply_sankey_workflow {

--- a/hydrant/workflows/panoply_ssgsea_workflow/panoply_ssgsea_workflow.wdl
+++ b/hydrant/workflows/panoply_ssgsea_workflow/panoply_ssgsea_workflow.wdl
@@ -1,9 +1,9 @@
 #
 # Copyright (c) 2024 The Broad Institute, Inc. All rights reserved.
 #
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_preprocess_gct/versions/8/plain-WDL/descriptor" as preprocess_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_ssgsea/versions/18/plain-WDL/descriptor" as ssgsea_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_ssgsea_report/versions/16/plain-WDL/descriptor" as ssgsea_report_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_preprocess_gct/panoply_preprocess_gct.wdl" as preprocess_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_ssgsea/panoply_ssgsea.wdl" as ssgsea_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_ssgsea_report/panoply_ssgsea_report.wdl" as ssgsea_report_wdl
 
 ################################################
 ##  workflow: panoply_preprocess_gct + panoply_ssgsea + panoply_ssgsea_report

--- a/hydrant/workflows/panoply_unified_workflow/panoply_unified_workflow.wdl
+++ b/hydrant/workflows/panoply_unified_workflow/panoply_unified_workflow.wdl
@@ -1,16 +1,16 @@
 #
 # Copyright (c) 2020 The Broad Institute, Inc. All rights reserved.
 #
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_select_all_pairs/versions/19/plain-WDL/descriptor" as select_pairs
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptac:panoply_normalize_filter_workflow/versions/37/plain-WDL/descriptor" as norm_filt_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_main/versions/75/plain-WDL/descriptor" as main_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_main_internal/versions/1/plain-WDL/descriptor" as main_internal_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_clumps_ptm_workflow/versions/23/plain-WDL/descriptor" as clumps_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_metaboanalyst_workflow/versions/4/plain-WDL/descriptor" as metab_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_nmf_workflow/versions/50/plain-WDL/descriptor" as nmf_wdl
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_unified_assemble_results/versions/33/plain-WDL/descriptor" as assemble_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_select_all_pairs/panoply_select_all_pairs.wdl" as select_pairs
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_normalize_filter_workflow/panoply_normalize_filter_workflow.wdl" as norm_filt_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_main/panoply_main.wdl" as main_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_main_internal/panoply_main_internal.wdl" as main_internal_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_clumps_ptm_workflow/panoply_clumps_ptm_workflow.wdl" as clumps_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_metaboanalyst_workflow/panoply_metaboanalyst_workflow.wdl" as metab_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/workflows/panoply_nmf_workflow/panoply_nmf_workflow.wdl" as nmf_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_unified_assemble_results/panoply_unified_assemble_results.wdl" as assemble_wdl
 
-import "https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_check_yaml_default/versions/9/plain-WDL/descriptor" as check_yaml_default_wdl
+import "https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_check_yaml_default/panoply_check_yaml_default.wdl" as check_yaml_default_wdl
 
 
 workflow panoply_unified_workflow {


### PR DESCRIPTION
## Summary

- All 14 workflow WDLs under `hydrant/workflows/` had their `import` statements updated
- Firecloud API URLs (e.g. `https://api.firecloud.org/ga4gh/v1/tools/broadcptacdev:panoply_ssgsea/versions/15/plain-WDL/descriptor`) are replaced with GitHub raw URLs pointing to this branch (e.g. `https://raw.githubusercontent.com/broadinstitute/PANOPLY/issue-githubWDL/hydrant/tasks/panoply_ssgsea/panoply_ssgsea.wdl`)
- Each tool name was resolved to the correct local path — `hydrant/workflows/` for sub-workflows, `hydrant/tasks/` for individual tasks

## Why

Versioning WDL imports via Firecloud version numbers is fragile and decoupled from git history. Using GitHub raw URLs ties the imports directly to the branch/commit, making version control the single source of truth.

## Reviewer notes

- The branch name in all URLs is hardcoded to `issue-githubWDL` — when this is merged to `dev` or another long-lived branch, the URLs should be updated accordingly (or a variable/script approach adopted for branch-agnostic imports)
- No task WDL content was changed, only import statements in workflow WDLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)